### PR TITLE
Print the path origin as zero in the Unicode and ASCII exporters.

### DIFF
--- a/base/distance_grid.py
+++ b/base/distance_grid.py
@@ -27,7 +27,7 @@ class DistanceGrid(Grid):
             _, self.maximum = self._distances.max
 
     def contents_of(self, cell: Cell) -> str:
-        if self.distances is not None and self.distances[cell]:
+        if self.distances is not None and self.distances[cell] is not None:
             return format(self.distances[cell], "02X").center(3)
         else:
             return super().contents_of(cell)


### PR DESCRIPTION
Currently, the origin of the path is not marked in the Unicode and ASCII exporters.  This change will print zero ('00') in the origin cell (what would be blue in a PNG export).  It may be a matter of taste, but it is something I found helpful.

